### PR TITLE
Change is_inputs_valid to take slice

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use num_traits::Float;
 
-pub fn is_inputs_valid<T>(times: &Vec<T>, points: &Vec<Vec<T>>) -> bool
+pub fn is_inputs_valid<T>(times: &[T], points: &[Vec<T>]) -> bool
 where
     T: Float,
 {


### PR DESCRIPTION
Suggested by clippy:

```text
warning: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
 --> src/utils.rs:3:34
  |
3 | pub fn is_inputs_valid<T>(times: &Vec<T>, points: &Vec<Vec<T>>) -> bool
  |                                  ^^^^^^^ help: change this to: `&[T]`
  |
  = note: `#[warn(clippy::ptr_arg)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices.
 --> src/utils.rs:3:51
  |
3 | pub fn is_inputs_valid<T>(times: &Vec<T>, points: &Vec<Vec<T>>) -> bool
  |                                                   ^^^^^^^^^^^^ help: change this to: `&[Vec<T>]`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
```