### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["spline", "robotics", "interpolation"]
 categories = ["algorithms"]
 repository = "https://github.com/openrr/trajectory"
 documentation = "http://docs.rs/trajectory"
-readme = "README.md"
 
 # Note: num-traits is public dependency.
 [dependencies]


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field if readme is in the default location (`readme = "README.md"`).
