### PR TITLE
Fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
   RUST_BACKTRACE: 1
 
 defaults:
@@ -18,8 +19,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: cargo fmt -- --check
-      if: matrix.rust == 'stable'
-    - run: cargo build --verbose
-    - run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
+      - run: cargo fmt -- --check
+      - run: cargo clippy --all-targets
+      - run: cargo build
+      - run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: [ "v[0-9]+.*" ]
+    tags: ['v[0-9]+.*']
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
       - run: cargo package
       - uses: taiki-e/create-gh-release-action@v1
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ documentation = "http://docs.rs/trajectory"
 num-traits = "0.2"
 
 [dev-dependencies]
+assert_approx_eq = "1"
 gnuplot = "0.0"

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -37,11 +37,11 @@ fn main() {
         .lines(&times, &positions0, &[Caption("Position"), Color("red")])
         .lines(&times, &velocities0, &[Caption("Velocity"), Color("green")])
         .lines(&times, &accs0, &[Caption("Acceleration"), Color("blue")]);
-    fg.show();
+    let _ = fg.show();
     let mut fg = Figure::new();
     fg.axes2d()
         .lines(&times, &positions1, &[Caption("Position"), Color("red")])
         .lines(&times, &velocities1, &[Caption("Velocity"), Color("green")])
         .lines(&times, &accs1, &[Caption("Acceleration"), Color("blue")]);
-    fg.show();
+    let _ = fg.show();
 }

--- a/src/cubic_spline.rs
+++ b/src/cubic_spline.rs
@@ -26,6 +26,7 @@ impl<T> CubicSpline<T>
 where
     T: Float,
 {
+    #[allow(clippy::many_single_char_names, clippy::just_underscores_and_digits)]
     pub fn new(times: Vec<T>, points: Vec<Vec<T>>) -> Option<Self> {
         if !is_inputs_valid(&times, &points) {
             return None;
@@ -41,7 +42,7 @@ where
         let n = points.len() - 1;
 
         // size of a is n+1
-        let a = points.iter().map(|p| p.clone()).collect::<Vec<_>>();
+        let a = points.clone();
         // size of h is n
         let mut h = vec![_0; n];
         for i in 0..n {

--- a/src/linear.rs
+++ b/src/linear.rs
@@ -88,6 +88,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_approx_eq::assert_approx_eq;
+
     #[test]
     fn test_linear() {
         let times = vec![0.0, 1.0, 3.0, 4.0];
@@ -101,16 +103,16 @@ mod tests {
         let p0 = ip.position(-0.5);
         assert!(p0.is_none());
         let p1 = ip.position(0.5).unwrap();
-        assert_eq!(p1[0], 1.0);
-        assert_eq!(p1[1], -2.0);
+        assert_approx_eq!(p1[0], 1.0);
+        assert_approx_eq!(p1[1], -2.0);
         let p2 = ip.position(1.0).unwrap();
-        assert_eq!(p2[0], 2.0);
-        assert_eq!(p2[1], -3.0);
+        assert_approx_eq!(p2[0], 2.0);
+        assert_approx_eq!(p2[1], -3.0);
         let p3 = ip.position(3.0).unwrap();
-        assert_eq!(p3[0], 3.0);
-        assert_eq!(p3[1], 3.0);
+        assert_approx_eq!(p3[0], 3.0);
+        assert_approx_eq!(p3[1], 3.0);
         let p4 = ip.position(3.5).unwrap();
-        assert_eq!(p4[0], 2.0);
-        assert_eq!(p4[1], 4.0);
+        assert_approx_eq!(p4[0], 2.0);
+        assert_approx_eq!(p4[1], 4.0);
     }
 }


### PR DESCRIPTION
- Fix clippy::float_cmp warning
- Fix clippy::map_clone warning
- Fix clippy::iter_cloned_collect warning
- Ignore clippy::many_single_char_names warning
- Ignore clippy::just_underscores_and_digits warning
- Fix unused_must_use warning
- Add clippy check to CI
- Alway use latest stable Rust