### PR TITLE
Remove doc URL from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 keywords = ["spline", "robotics", "interpolation"]
 categories = ["algorithms"]
 repository = "https://github.com/openrr/trajectory"
-documentation = "http://docs.rs/trajectory"
 
 # Note: num-traits is public dependency.
 [dependencies]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field

> If no URL is specified in the manifest file, crates.io will
> automatically link your crate to the corresponding docs.rs page.