### PR TITLE
Fix build error in plot example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = "0.2"
 
 [dev-dependencies]
 assert_approx_eq = "1"
-gnuplot = "0.0"
+gnuplot = "0.0.46"
 
 [lints]
 workspace = true

--- a/examples/plot.rs
+++ b/examples/plot.rs
@@ -34,22 +34,38 @@ fn main() {
     }
     let mut fg = Figure::new();
     fg.axes2d()
-        .lines(&times, &positions0, &[Caption("Position"), Color("red")])
-        .lines(&times, &velocities0, &[Caption("Velocity"), Color("green")])
+        .lines(
+            &times,
+            &positions0,
+            &[Caption("Position"), Color("red".into())],
+        )
+        .lines(
+            &times,
+            &velocities0,
+            &[Caption("Velocity"), Color("green".into())],
+        )
         .lines(
             &times,
             &accelerations0,
-            &[Caption("Acceleration"), Color("blue")],
+            &[Caption("Acceleration"), Color("blue".into())],
         );
     let _ = fg.show();
     let mut fg = Figure::new();
     fg.axes2d()
-        .lines(&times, &positions1, &[Caption("Position"), Color("red")])
-        .lines(&times, &velocities1, &[Caption("Velocity"), Color("green")])
+        .lines(
+            &times,
+            &positions1,
+            &[Caption("Position"), Color("red".into())],
+        )
+        .lines(
+            &times,
+            &velocities1,
+            &[Caption("Velocity"), Color("green".into())],
+        )
         .lines(
             &times,
             &accelerations1,
-            &[Caption("Acceleration"), Color("blue")],
+            &[Caption("Acceleration"), Color("blue".into())],
         );
     let _ = fg.show();
 }


### PR DESCRIPTION
Currently, the build of examples/plot.rs is broken due to the following error:

https://github.com/openrr/trajectory/actions/runs/16500963122/job/46659123159#step:5:47

```
error[E0308]: mismatched types
  --> examples/plot.rs:37:66
   |
37 |         .lines(&times, &positions0, &[Caption("Position"), Color("red")])
   |                                                            ----- ^^^^^ expected `ColorType<&str>`, found `&str`
   |                                                            |
   |                                                            arguments to this enum variant are incorrect
   |
   = note:   expected enum `gnuplot::ColorType<&str>`
           found reference `&'static str`
```

This is because our version specification in the manifest allows any 0.0.x version. Cargo treats the first non-zero version of `<major>.<miner>.<patch>` like a major version, so if the version number is 0.0.x, you can introduce breaking changes at any 0.0.x release. See also the [Cargo reference](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#default-requirements).

https://github.com/openrr/trajectory/blob/c1a8d23d5022918c2c76ef4b8ff4511d5cfbf8f4/Cargo.toml#L22
